### PR TITLE
STEP 2: Complete the prep requirement for bump update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ wen_new_standard = { path = "programs/wen_new_standard", features = [
 wen_royalty_distribution = { path = "programs/wen_royalty_distribution", features = [
   "cpi",
 ] }
+spl-transfer-hook-interface = "0.5.1"
+spl-tlv-account-resolution = "0.4.0"
 
 [profile.release]
 overflow-checks = true

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -26,13 +26,8 @@ idl-build = [
 ]
 
 [dependencies]
-anchor-lang = { version = "0.30.0", features = [
-  "init-if-needed",
-  "interface-instructions",
-] }
-anchor-spl = "0.30.0"
-spl-transfer-hook-interface = { version = "0.5.0" }
-spl-tlv-account-resolution = "0.4.0"
-wen_royalty_distribution = { path = "../wen_royalty_distribution", features = [
-  "cpi",
-] }
+anchor-lang.workspace = true
+anchor-spl.workspace = true
+wen_royalty_distribution.workspace = true
+spl-transfer-hook-interface.workspace = true
+spl-tlv-account-resolution.workspace = true

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2021"
 [package.metadata.docs.rs]
 tags = ["wns", "alpha", "solana", "token_extensions"]
 
-[profile.release]
-overflow-checks = true
-
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "wen_new_standard"

--- a/programs/wen_new_standard/src/instructions/bump/group.rs
+++ b/programs/wen_new_standard/src/instructions/bump/group.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct UpdateBumpGroup<'info> {
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [GROUP_ACCOUNT_SEED, group.mint.as_ref()],
+        bump,
+    )]
+    pub group: Account<'info, TokenGroup>,
+}
+
+pub fn handler(ctx: Context<UpdateBumpGroup>) -> Result<()> {
+    let group = &mut ctx.accounts.group;
+    group.bump = ctx.bumps.group;
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/bump/group_member.rs
+++ b/programs/wen_new_standard/src/instructions/bump/group_member.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct UpdateBumpGroupMember<'info> {
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [MEMBER_ACCOUNT_SEED, member.mint.as_ref()],
+        bump,
+    )]
+    pub member: Account<'info, TokenGroupMember>,
+}
+
+pub fn handler(ctx: Context<UpdateBumpGroupMember>) -> Result<()> {
+    let member = &mut ctx.accounts.member;
+    member.bump = ctx.bumps.member;
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/bump/manager.rs
+++ b/programs/wen_new_standard/src/instructions/bump/manager.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct UpdateBumpManager<'info> {
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [MANAGER_SEED],
+        bump,
+    )]
+    pub manager: Account<'info, Manager>,
+}
+
+pub fn handler(ctx: Context<UpdateBumpManager>) -> Result<()> {
+    let manager = &mut ctx.accounts.manager;
+    manager.bump = ctx.bumps.manager;
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/bump/mod.rs
+++ b/programs/wen_new_standard/src/instructions/bump/mod.rs
@@ -1,0 +1,7 @@
+pub mod group;
+pub mod group_member;
+pub mod manager;
+
+pub use group::*;
+pub use group_member::*;
+pub use manager::*;

--- a/programs/wen_new_standard/src/instructions/group/create.rs
+++ b/programs/wen_new_standard/src/instructions/group/create.rs
@@ -123,6 +123,7 @@ pub fn handler(ctx: Context<CreateGroupAccount>, args: CreateGroupAccountArgs) -
     group.update_authority = ctx.accounts.authority.key();
     group.mint = ctx.accounts.mint.key();
     group.size = 0;
+    group.bump = ctx.bumps.group;
 
     // mint to receiver
     ctx.accounts.mint_to_receiver()?;

--- a/programs/wen_new_standard/src/instructions/manager/init.rs
+++ b/programs/wen_new_standard/src/instructions/manager/init.rs
@@ -17,3 +17,8 @@ pub struct InitManagerAccount<'info> {
     pub manager: Account<'info, Manager>,
     pub system_program: Program<'info, System>,
 }
+
+pub fn handler(ctx: Context<InitManagerAccount>) -> Result<()> {
+    ctx.accounts.manager.bump = ctx.bumps.manager;
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/mint/group/add.rs
+++ b/programs/wen_new_standard/src/instructions/mint/group/add.rs
@@ -71,6 +71,7 @@ pub fn handler(ctx: Context<AddGroup>) -> Result<()> {
     member.group = group.key();
     member.mint = ctx.accounts.mint.key();
     member.member_number = group.size;
+    member.bump = ctx.bumps.member;
 
     let member_address = member.key();
 

--- a/programs/wen_new_standard/src/instructions/mod.rs
+++ b/programs/wen_new_standard/src/instructions/mod.rs
@@ -1,9 +1,11 @@
+pub mod bump;
 pub mod group;
 pub mod manager;
 pub mod mint;
 pub mod resize;
 pub mod royalty;
 
+pub use bump::*;
 pub use group::*;
 pub use manager::*;
 pub use mint::*;

--- a/programs/wen_new_standard/src/instructions/mod.rs
+++ b/programs/wen_new_standard/src/instructions/mod.rs
@@ -1,9 +1,11 @@
 pub mod group;
 pub mod manager;
 pub mod mint;
+pub mod resize;
 pub mod royalty;
 
 pub use group::*;
 pub use manager::*;
 pub use mint::*;
+pub use resize::*;
 pub use royalty::*;

--- a/programs/wen_new_standard/src/instructions/resize/approve.rs
+++ b/programs/wen_new_standard/src/instructions/resize/approve.rs
@@ -17,6 +17,5 @@ pub struct ResizeApprove<'info> {
 }
 
 pub fn handler(_: Context<ResizeApprove>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/approve.rs
+++ b/programs/wen_new_standard/src/instructions/resize/approve.rs
@@ -1,0 +1,22 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeApprove<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + ApproveAccount::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+    )]
+    pub approve_account: Account<'info, ApproveAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeApprove>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeGroup<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + TokenGroup::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [GROUP_ACCOUNT_SEED, group.mint.as_ref()],
+        bump,
+    )]
+    pub group: Account<'info, TokenGroup>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeGroup>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group.rs
@@ -19,6 +19,5 @@ pub struct ResizeGroup<'info> {
 }
 
 pub fn handler(_: Context<ResizeGroup>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/group_member.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group_member.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeGroupMember<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + TokenGroupMember::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [MEMBER_ACCOUNT_SEED, member.mint.as_ref()],
+        bump,
+    )]
+    pub member: Account<'info, TokenGroupMember>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeGroupMember>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group_member.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group_member.rs
@@ -19,6 +19,5 @@ pub struct ResizeGroupMember<'info> {
 }
 
 pub fn handler(_: Context<ResizeGroupMember>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/manager.rs
+++ b/programs/wen_new_standard/src/instructions/resize/manager.rs
@@ -19,6 +19,5 @@ pub struct ResizeManager<'info> {
 }
 
 pub fn handler(_: Context<ResizeManager>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/manager.rs
+++ b/programs/wen_new_standard/src/instructions/resize/manager.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeManager<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + Manager::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [MANAGER_SEED],
+        bump,
+    )]
+    pub manager: Account<'info, Manager>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeManager>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/mod.rs
+++ b/programs/wen_new_standard/src/instructions/resize/mod.rs
@@ -1,0 +1,9 @@
+pub mod approve;
+pub mod group;
+pub mod group_member;
+pub mod manager;
+
+pub use approve::*;
+pub use group::*;
+pub use group_member::*;
+pub use manager::*;

--- a/programs/wen_new_standard/src/instructions/royalty/approve.rs
+++ b/programs/wen_new_standard/src/instructions/royalty/approve.rs
@@ -103,6 +103,7 @@ pub fn handler(ctx: Context<ApproveTransfer>, amount: u64) -> Result<()> {
     // Load clock and write slot
     let clock = Clock::get()?;
     ctx.accounts.approve_account.slot = clock.slot;
+    ctx.accounts.approve_account.bump = ctx.bumps.approve_account;
 
     // get royalty basis points from metadata Vec(String, String)
     let royalty_basis_points = metadata

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -22,9 +22,8 @@ pub mod wen_new_standard {
         Manager instructions
     */
     /// Init manager account
-    pub fn init_manager_account(_ctx: Context<InitManagerAccount>) -> Result<()> {
-        // create manager happens in the macro, no extra processor needed
-        Ok(())
+    pub fn init_manager_account(ctx: Context<InitManagerAccount>) -> Result<()> {
+        instructions::manager::init::handler(ctx)
     }
 
     /// Token group instructions
@@ -128,6 +127,17 @@ pub mod wen_new_standard {
     }
     /**/
 
-    /* Assign bump instructions (upcoming) */
+    /* Assign bump instructions */
+    pub fn update_bump_manager(ctx: Context<UpdateBumpManager>) -> Result<()> {
+        instructions::bump::manager::handler(ctx)
+    }
+
+    pub fn update_bump_group(ctx: Context<UpdateBumpGroup>) -> Result<()> {
+        instructions::bump::group::handler(ctx)
+    }
+
+    pub fn update_bump_group_member(ctx: Context<UpdateBumpGroupMember>) -> Result<()> {
+        instructions::bump::group_member::handler(ctx)
+    }
     /**/
 }

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -109,4 +109,25 @@ pub mod wen_new_standard {
     pub fn approve_transfer(ctx: Context<ApproveTransfer>, buy_amount: u64) -> Result<()> {
         instructions::royalty::approve::handler(ctx, buy_amount)
     }
+
+    /* Resize instructions */
+    pub fn resize_manager(ctx: Context<ResizeManager>) -> Result<()> {
+        instructions::resize::manager::handler(ctx)
+    }
+
+    pub fn resize_group(ctx: Context<ResizeGroup>) -> Result<()> {
+        instructions::resize::group::handler(ctx)
+    }
+
+    pub fn resize_group_member(ctx: Context<ResizeGroupMember>) -> Result<()> {
+        instructions::resize::group_member::handler(ctx)
+    }
+
+    pub fn resize_approve(ctx: Context<ResizeApprove>) -> Result<()> {
+        instructions::resize::approve::handler(ctx)
+    }
+    /**/
+
+    /* Assign bump instructions (upcoming) */
+    /**/
 }

--- a/programs/wen_new_standard/src/state/approve.rs
+++ b/programs/wen_new_standard/src/state/approve.rs
@@ -4,4 +4,6 @@ use anchor_lang::prelude::*;
 #[derive(InitSpace)]
 pub struct ApproveAccount {
     pub slot: u64,
+    /// Token PDA bump
+    pub bump: u8,
 }

--- a/programs/wen_new_standard/src/state/group.rs
+++ b/programs/wen_new_standard/src/state/group.rs
@@ -16,16 +16,19 @@ pub struct TokenGroup {
     pub size: u32,
     /// The maximum number of group members
     pub max_size: u32,
+    /// Token PDA bump
+    pub bump: u8,
 }
 
 impl TokenGroup {
     /// Creates a new `TokenGroup` state
-    pub fn new(mint: &Pubkey, update_authority: Pubkey, max_size: u32) -> Self {
+    pub fn new(mint: &Pubkey, update_authority: Pubkey, max_size: u32, bump: u8) -> Self {
         Self {
             mint: *mint,
             update_authority,
             size: 0,
             max_size,
+            bump,
         }
     }
 

--- a/programs/wen_new_standard/src/state/manager.rs
+++ b/programs/wen_new_standard/src/state/manager.rs
@@ -3,16 +3,12 @@ use anchor_lang::prelude::*;
 /// Data struct for a `Manager`
 #[account()]
 #[derive(InitSpace)]
-pub struct Manager {}
+pub struct Manager {
+    pub bump: u8,
+}
 impl Manager {
     /// Creates a new `Manager` state
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for Manager {
-    fn default() -> Self {
-        Self::new()
+    pub fn new(bump: u8) -> Self {
+        Self { bump }
     }
 }

--- a/programs/wen_new_standard/src/state/member.rs
+++ b/programs/wen_new_standard/src/state/member.rs
@@ -11,14 +11,17 @@ pub struct TokenGroupMember {
     pub group: Pubkey,
     /// The member number
     pub member_number: u32,
+    /// Token PDA bump
+    pub bump: u8,
 }
 impl TokenGroupMember {
     /// Creates a new `TokenGroupMember` state
-    pub fn new(mint: &Pubkey, group: &Pubkey, member_number: u32) -> Self {
+    pub fn new(mint: &Pubkey, group: &Pubkey, member_number: u32, bump: u8) -> Self {
         Self {
             mint: *mint,
             group: *group,
             member_number,
+            bump,
         }
     }
 }

--- a/programs/wen_royalty_distribution/Cargo.toml
+++ b/programs/wen_royalty_distribution/Cargo.toml
@@ -20,7 +20,7 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 
 [dependencies]
-anchor-lang = { version = "0.30.0", features = ["init-if-needed"] }
-anchor-spl = "0.30.0"
-spl-transfer-hook-interface = { version = "0.5.0" }
-spl-tlv-account-resolution = "0.4.0"
+anchor-lang = { workspace = true, features = ["init-if-needed"] }
+anchor-spl.workspace = true
+spl-transfer-hook-interface.workspace = true
+spl-tlv-account-resolution.workspace = true

--- a/programs/wen_royalty_distribution/src/instructions/bump.rs
+++ b/programs/wen_royalty_distribution/src/instructions/bump.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct UpdateDistributionBump<'info> {
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [distribution_account.group_mint.as_ref(), distribution_account.payment_mint.as_ref()],
+        bump
+    )]
+    pub distribution_account: Account<'info, DistributionAccount>,
+}
+
+pub fn handler(ctx: Context<UpdateDistributionBump>) -> Result<()> {
+    let distribution_account = &mut ctx.accounts.distribution_account;
+    distribution_account.bump = ctx.bumps.distribution_account;
+    Ok(())
+}

--- a/programs/wen_royalty_distribution/src/instructions/mod.rs
+++ b/programs/wen_royalty_distribution/src/instructions/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod claim;
 pub mod initialize;
+pub mod resize;
 pub mod update;
 
 pub use claim::*;
 pub use initialize::*;
+pub use resize::*;
 pub use update::*;

--- a/programs/wen_royalty_distribution/src/instructions/mod.rs
+++ b/programs/wen_royalty_distribution/src/instructions/mod.rs
@@ -1,10 +1,12 @@
 #![allow(ambiguous_glob_reexports)]
 
+pub mod bump;
 pub mod claim;
 pub mod initialize;
 pub mod resize;
 pub mod update;
 
+pub use bump::*;
 pub use claim::*;
 pub use initialize::*;
 pub use resize::*;

--- a/programs/wen_royalty_distribution/src/instructions/resize.rs
+++ b/programs/wen_royalty_distribution/src/instructions/resize.rs
@@ -24,6 +24,11 @@ pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
     let new_length = 8 + DistributionAccount::INIT_SPACE + 1;
     let rent_required = Rent::get()?.minimum_balance(new_length);
 
+    // Account already resized if data_len == new_length
+    if distribution_account.data_len() == new_length {
+        return Ok(());
+    }
+
     transfer(
         CpiContext::new(
             ctx.accounts.system_program.to_account_info(),
@@ -36,7 +41,5 @@ pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
     )?;
 
     distribution_account.realloc(new_length, false)?;
-
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_royalty_distribution/src/instructions/resize.rs
+++ b/programs/wen_royalty_distribution/src/instructions/resize.rs
@@ -1,0 +1,42 @@
+use crate::DistributionAccount;
+use anchor_lang::{
+    prelude::*,
+    system_program::{transfer, Transfer},
+};
+
+#[derive(Accounts)]
+pub struct ResizeDistribution<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        constraint = !distribution_account.data_is_empty()
+    )]
+    /// CHECK: Owner check is done, only state account in this program
+    pub distribution_account: UncheckedAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
+    let distribution_account = &ctx.accounts.distribution_account;
+    require_eq!(distribution_account.owner.key(), crate::id());
+
+    let new_length = 8 + DistributionAccount::INIT_SPACE + 1;
+    let rent_required = Rent::get()?.minimum_balance(new_length);
+
+    transfer(
+        CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            Transfer {
+                from: ctx.accounts.payer.to_account_info(),
+                to: ctx.accounts.distribution_account.to_account_info(),
+            },
+        ),
+        rent_required,
+    )?;
+
+    distribution_account.realloc(new_length, false)?;
+
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_royalty_distribution/src/lib.rs
+++ b/programs/wen_royalty_distribution/src/lib.rs
@@ -37,4 +37,9 @@ pub mod wen_royalty_distribution {
     pub fn claim_distribution(ctx: Context<ClaimDistribution>) -> Result<()> {
         instructions::claim::handler(ctx)
     }
+
+    /// Resize old accounts for backwards compatibility.
+    pub fn resize_distribution(ctx: Context<ResizeDistribution>) -> Result<()> {
+        instructions::resize::handler(ctx)
+    }
 }

--- a/programs/wen_royalty_distribution/src/lib.rs
+++ b/programs/wen_royalty_distribution/src/lib.rs
@@ -42,4 +42,9 @@ pub mod wen_royalty_distribution {
     pub fn resize_distribution(ctx: Context<ResizeDistribution>) -> Result<()> {
         instructions::resize::handler(ctx)
     }
+
+    /// Update bump field for a distribution account
+    pub fn update_bump_distribution(ctx: Context<UpdateDistributionBump>) -> Result<()> {
+        instructions::bump::handler(ctx)
+    }
 }

--- a/programs/wen_royalty_distribution/src/state.rs
+++ b/programs/wen_royalty_distribution/src/state.rs
@@ -21,6 +21,8 @@ pub struct DistributionAccount {
     pub payment_mint: Pubkey,
     #[max_len(10)] // we currently support 10 creators
     pub claim_data: Vec<Creator>,
+    /// PDA bump
+    pub bump: u8,
 }
 
 impl DistributionAccount {

--- a/programs/wen_wns_marketplace/Cargo.toml
+++ b/programs/wen_wns_marketplace/Cargo.toml
@@ -26,4 +26,4 @@ anchor-lang.workspace = true
 anchor-spl.workspace = true
 wen_new_standard.workspace = true
 wen_royalty_distribution.workspace = true
-spl-transfer-hook-interface = "^0.5.1"
+spl-transfer-hook-interface.workspace = true

--- a/programs/wen_wns_marketplace/src/instructions/listing/royalty.rs
+++ b/programs/wen_wns_marketplace/src/instructions/listing/royalty.rs
@@ -21,6 +21,9 @@ pub struct ClaimRoyalty<'info> {
     #[account(
         mut,
         has_one = payment_mint,
+        seeds = [distribution.group_mint.as_ref(), payment_mint.key().as_ref()],
+        seeds::program = wen_distribution_program.key(),
+        bump
     )]
     pub distribution: Account<'info, DistributionAccount>,
 


### PR DESCRIPTION
This PR concludes the account resizing for all PDAs and updating the bump values as well. The upcoming initialize functions would automatically add the bump field for any newly created pda accounts. This must be deployed after #81 is deployed and closed.