### PR TITLE
Base58 Compare Pubkeys in Specs. Pin Anchor sha.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7368e171b3a317885dc08ec0f74eed9d0ad6c726cc819593aed81440dca926"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -85,8 +84,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f527df85a8cba3f2bea04e46ed71b66e525ea378c7fec538aa205f4520b73e31"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "bs58 0.5.1",
@@ -98,8 +96,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb1dc1845cf8636c2e046a274ca074dabd3884ac8ed11cc4ed64b7e8ef5a318"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -109,8 +106,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f382e41514c59a77ffa7bb1a47df9a0359564a749b6934485c742c11962e540"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -120,8 +116,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473a122aeed3f6b666438236338d2ef7833ee5fdc5688e1baa80185d61088a53"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -132,8 +127,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f88c7ffe2eb40aeac43ffd0d74a6671581158aedfaa0552330a2ef92fa5c889"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -149,8 +143,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9b97c99dcec135aae0ff908c14bcfcd3e78cfc16a0c6f245135038f0e6d390"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -160,11 +153,10 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbece98f6ad9c37070edc0841326c9623a249346cd74f433e7cef69b14f7f31d"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
- "borsh-derive-internal 0.10.3",
+ "borsh-derive-internal 0.9.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -173,8 +165,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8badbe2648bc99a85ee05a7a5f9512e5e2af8ffac71476a69350cb278057ac53"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -184,8 +175,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41feb9c1cd9f4b0fad1c004fc8f289183f3ce27e9db38fa6e434470c716fb1e"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -200,7 +190,7 @@ dependencies = [
  "arrayref",
  "base64 0.21.7",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.9.3",
  "bytemuck",
  "getrandom 0.2.14",
  "solana-program",
@@ -210,8 +200,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang-idl"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29da81eae478b1bb846749b06b8a2cb9c6f9ed26ca793b0c916793fdf36adab"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -223,8 +212,7 @@ dependencies = [
 [[package]]
 name = "anchor-spl"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcee54a30b27ea8317ca647759b5d9701a8c7caaaa0c922c6d3c306a7278a7a"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account",
@@ -238,8 +226,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac53f2378bc08e89e20c2b893c01986ffd34cfbc69a17e35bd6f754753e9fdad"
+source = "git+https://github.com/coral-xyz/anchor#bcf3862ef758755e4a93bc381227bc97fe5afbf9"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,12 @@ members = ["programs/*"]
 resolver = "2"
 
 [workspace.dependencies]
-anchor-lang = { version = "0.30.0", features = ["init-if-needed", "interface-instructions"] }
-anchor-spl = { version = "0.30.0" }
-wen_new_standard = { path = "programs/wen_new_standard", features = [
-  "cpi",
+anchor-lang = { git = "https://github.com/coral-xyz/anchor", sha = "827c986618358c177a50c22ff8eb08bae6943784", features = [
+  "init-if-needed",
+  "interface-instructions",
 ] }
+anchor-spl = { git = "https://github.com/coral-xyz/anchor", sha = "827c986618358c177a50c22ff8eb08bae6943784" }
+wen_new_standard = { path = "programs/wen_new_standard", features = ["cpi"] }
 wen_royalty_distribution = { path = "programs/wen_royalty_distribution", features = [
   "cpi",
 ] }

--- a/tests/wen_new_standard.test.ts
+++ b/tests/wen_new_standard.test.ts
@@ -70,11 +70,15 @@ describe("wen_new_standard", () => {
       });
 
       it("should exist with a fixed seed", async () => {
-        expect(account.data).to.eql(Buffer.from([221, 78, 171, 233, 213, 142, 113, 56]));
+        expect(account.data).to.eql(
+          Buffer.from([221, 78, 171, 233, 213, 142, 113, 56])
+        );
       });
 
       it("should be owned by the program", async () => {
-        expect(account.owner).to.eql(program.programId);
+        expect((account.owner as PublicKey).toBase58()).to.eql(
+          program.programId.toBase58()
+        );
       });
     });
   });
@@ -154,11 +158,15 @@ describe("wen_new_standard", () => {
       });
 
       it("should be owned by the token extensions program", async () => {
-        expect(mintAccountInfo.owner).to.eql(TOKEN_2022_PROGRAM_ID);
+        expect(mintAccountInfo.owner.toBase58()).to.eql(
+          TOKEN_2022_PROGRAM_ID.toBase58()
+        );
       });
 
       it("should have metadata pointer", async () => {
-        expect(metadataPointer.metadataAddress).to.eql(mintPublicKey);
+        expect(metadataPointer.metadataAddress.toBase58()).to.eql(
+          mintPublicKey.toBase58()
+        );
       });
 
       it("should have right name set", async () => {
@@ -189,7 +197,10 @@ describe("wen_new_standard", () => {
 
         const instructions: TransactionInstruction[] = [];
         const rent = await getMinRentForWNSMint(connection, metadata, "member");
-        const currentRent = await connection.getBalance(mintPublicKey, "confirmed");
+        const currentRent = await connection.getBalance(
+          mintPublicKey,
+          "confirmed"
+        );
 
         if (currentRent < rent) {
           const lamportsDiff = rent - currentRent;
@@ -230,7 +241,10 @@ describe("wen_new_standard", () => {
       const creator1 = Keypair.generate();
       const creator2 = Keypair.generate();
 
-      const extraMetasAccount = getExtraMetasAccountPda(mintPublicKey, wnsProgramId);
+      const extraMetasAccount = getExtraMetasAccountPda(
+        mintPublicKey,
+        wnsProgramId
+      );
 
       let metadata: TokenMetadata | null;
 
@@ -379,7 +393,12 @@ describe("wen_new_standard", () => {
           ];
 
           try {
-            await sendAndConfirmWNSTransaction(connection, instructions, provider, false);
+            await sendAndConfirmWNSTransaction(
+              connection,
+              instructions,
+              provider,
+              false
+            );
           } catch (err) {
             logs = err.logs;
           }
@@ -431,9 +450,8 @@ describe("wen_new_standard", () => {
             1 * LAMPORTS_PER_SOL
           );
 
-          const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash(
-            "confirmed"
-          );
+          const { blockhash, lastValidBlockHeight } =
+            await connection.getLatestBlockhash("confirmed");
 
           await connection.confirmTransaction({
             blockhash,
@@ -477,7 +495,11 @@ describe("wen_new_standard", () => {
             transferIx,
           ];
 
-          await sendAndConfirmWNSTransaction(connection, instructions, provider);
+          await sendAndConfirmWNSTransaction(
+            connection,
+            instructions,
+            provider
+          );
 
           receiverTokenAccountData = await getAccount(
             connection,
@@ -492,7 +514,9 @@ describe("wen_new_standard", () => {
         });
 
         it("should be owned by the new owner", async () => {
-          expect(receiverTokenAccountData.owner).to.eql(receiver.publicKey);
+          expect(receiverTokenAccountData.owner.toBase58()).to.eql(
+            receiver.publicKey.toBase58()
+          );
         });
       });
     });
@@ -531,21 +555,31 @@ describe("wen_new_standard", () => {
           .instruction();
 
         const instructions = [burnIx];
-        await sendAndConfirmWNSTransaction(connection, instructions, provider, true, [
-          receiver,
-        ]);
+        await sendAndConfirmWNSTransaction(
+          connection,
+          instructions,
+          provider,
+          true,
+          [receiver]
+        );
 
         tokenAccountInfo = await connection.getAccountInfo(
           receiverTokenAccount,
           "confirmed"
         );
-        mintAccountInfo = await connection.getAccountInfo(mintPublicKey, "confirmed");
+        mintAccountInfo = await connection.getAccountInfo(
+          mintPublicKey,
+          "confirmed"
+        );
 
         tokenAccountLamports = await connection.getBalance(
           receiverTokenAccount,
           "confirmed"
         );
-        mintAccountLamports = await connection.getBalance(mintPublicKey, "confirmed");
+        mintAccountLamports = await connection.getBalance(
+          mintPublicKey,
+          "confirmed"
+        );
 
         payerPostBurnBalance = await connection.getBalance(
           receiver.publicKey,
@@ -562,7 +596,9 @@ describe("wen_new_standard", () => {
         expect(mintAccountInfo).to.be.null;
       });
       it("should credit rent to payer", async () => {
-        expect(payerPostBurnBalance).to.eql(payerPreBurnBalance + totalBurnRent);
+        expect(payerPostBurnBalance).to.eql(
+          payerPreBurnBalance + totalBurnRent
+        );
       });
     });
   });
@@ -623,20 +659,29 @@ describe("wen_new_standard", () => {
         });
 
       groupAccountInfo = await program.account.tokenGroup.getAccountInfo(group);
-      groupAccount = program.coder.accounts.decode("tokenGroup", groupAccountInfo.data);
+      groupAccount = program.coder.accounts.decode(
+        "tokenGroup",
+        groupAccountInfo.data
+      );
     });
 
     describe("after creating", () => {
       it("should be an account owned by the program", async () => {
-        expect(groupAccountInfo.owner).to.eql(program.programId);
+        expect(groupAccountInfo.owner.toBase58()).to.eql(
+          program.programId.toBase58()
+        );
       });
 
       it("should have an update authority", async () => {
-        expect(groupAccount.updateAuthority).to.eql(groupAuthorityPublicKey);
+        expect((groupAccount.updateAuthority as PublicKey).toBase58()).to.eql(
+          groupAuthorityPublicKey.toBase58()
+        );
       });
 
       it("should reference the group mint", async () => {
-        expect(groupAccount.mint).to.eql(groupMintPublicKey);
+        expect((groupAccount.mint as PublicKey).toBase58()).to.eql(
+          groupMintPublicKey.toBase58()
+        );
       });
 
       it("should have a max size", async () => {
@@ -663,7 +708,10 @@ describe("wen_new_standard", () => {
 
         const instructions: TransactionInstruction[] = [];
         const rent = await getMinRentForWNSMint(connection, metadata, "member");
-        const currentRent = await connection.getBalance(groupMintPublicKey, "confirmed");
+        const currentRent = await connection.getBalance(
+          groupMintPublicKey,
+          "confirmed"
+        );
 
         if (currentRent < rent) {
           const lamportsDiff = rent - currentRent;
@@ -686,9 +734,13 @@ describe("wen_new_standard", () => {
           })
         );
 
-        await sendAndConfirmWNSTransaction(connection, instructions, provider, true, [
-          groupAuthorityKeyPair,
-        ]);
+        await sendAndConfirmWNSTransaction(
+          connection,
+          instructions,
+          provider,
+          true,
+          [groupAuthorityKeyPair]
+        );
 
         metadata = await getTokenMetadata(
           connection,
@@ -736,7 +788,7 @@ describe("wen_new_standard", () => {
               receiver: mintAuthPublicKey,
               associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
               manager,
-  
+
               systemProgram: SystemProgram.programId,
               tokenProgram: TOKEN_2022_PROGRAM_ID,
             })
@@ -762,9 +814,8 @@ describe("wen_new_standard", () => {
               commitment: "confirmed",
             });
 
-          memberAccountInfo = await program.account.tokenGroupMember.getAccountInfo(
-            member
-          );
+          memberAccountInfo =
+            await program.account.tokenGroupMember.getAccountInfo(member);
           memberAccount = program.coder.accounts.decode(
             "tokenGroupMember",
             memberAccountInfo.data
@@ -772,23 +823,32 @@ describe("wen_new_standard", () => {
         });
 
         it("should be an account owned by the program", async () => {
-          expect(memberAccountInfo.owner).to.eql(program.programId);
+          expect((memberAccountInfo.owner as PublicKey).toBase58()).to.eql(
+            program.programId.toBase58()
+          );
         });
         it("should point back to the group", async () => {
-          expect(memberAccount.group).to.eql(group);
+          expect((memberAccount.group as PublicKey).toBase58()).to.eql(
+            group.toBase58()
+          );
         });
         it("should have the right member number", async () => {
           expect(memberAccount.memberNumber.toString()).to.eql("1");
         });
         it("should have the right member mint", async () => {
-          expect(memberAccount.mint).to.eql(mintPublicKey);
+          expect((memberAccount.mint as PublicKey).toBase58()).to.eql(
+            mintPublicKey.toBase58()
+          );
         });
       });
 
       describe("the group", () => {
         let groupAccount;
         before(async () => {
-          groupAccount = await program.account.tokenGroup.fetch(group, "confirmed");
+          groupAccount = await program.account.tokenGroup.fetch(
+            group,
+            "confirmed"
+          );
         });
         it("should be a size of 1", async () => {
           expect(groupAccount.size).to.eql(1);
@@ -905,9 +965,8 @@ describe("wen_new_standard", () => {
               commitment: "confirmed",
             });
 
-          memberAccountInfo = await program.account.tokenGroupMember.getAccountInfo(
-            member
-          );
+          memberAccountInfo =
+            await program.account.tokenGroupMember.getAccountInfo(member);
         });
         it("should not point back to the group", async () => {
           expect(memberAccountInfo).to.be.null;
@@ -917,7 +976,10 @@ describe("wen_new_standard", () => {
       describe("the group", () => {
         let groupAccount;
         before(async () => {
-          groupAccount = await program.account.tokenGroup.fetch(group, "confirmed");
+          groupAccount = await program.account.tokenGroup.fetch(
+            group,
+            "confirmed"
+          );
         });
         it("should be a size of 0", async () => {
           expect(groupAccount.size).to.eql(0);

--- a/tests/wen_royalty_distribution.test.ts
+++ b/tests/wen_royalty_distribution.test.ts
@@ -41,7 +41,8 @@ describe("wen_royalty_distribution", () => {
   anchor.setProvider(provider);
   const { connection, wallet } = provider;
 
-  const wnsProgram = anchor.workspace.WenNewStandard as anchor.Program<WenNewStandard>;
+  const wnsProgram = anchor.workspace
+    .WenNewStandard as anchor.Program<WenNewStandard>;
   const wenDistributionProgram = anchor.workspace
     .WenRoyaltyDistribution as anchor.Program<WenRoyaltyDistribution>;
   const wenWnsMarketplace = anchor.workspace
@@ -135,7 +136,10 @@ describe("wen_royalty_distribution", () => {
         memberMintPublickey,
         wnsProgramId
       );
-      const approveAccount = getApproveAccountPda(memberMintPublickey, wnsProgramId);
+      const approveAccount = getApproveAccountPda(
+        memberMintPublickey,
+        wnsProgramId
+      );
 
       const listingAmount = new anchor.BN(2 * LAMPORTS_PER_SOL);
       const royaltyBasisPoints = 1000;
@@ -248,7 +252,9 @@ describe("wen_royalty_distribution", () => {
             tokenProgram: TOKEN_2022_PROGRAM_ID,
             systemProgram: SystemProgram.programId,
           })
-          .preInstructions([ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 })])
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
+          ])
           .postInstructions(ixs)
           .signers([memberMintKeypair, seller])
           .rpc(preflightConfig);
@@ -260,15 +266,21 @@ describe("wen_royalty_distribution", () => {
         });
 
         it("should be owned by the distribution program", () => {
-          expect(distributionAccountInfo.owner).to.eql(wenDistributionProgramId);
+          expect(distributionAccountInfo.owner.toBase58()).to.eql(
+            wenDistributionProgramId.toBase58()
+          );
         });
 
         it("should point the correct group mint account address", () => {
-          expect(distributionAccountData.groupMint).to.eql(groupMintPublicKey);
+          expect(
+            (distributionAccountData.groupMint as PublicKey).toBase58()
+          ).to.eql(groupMintPublicKey.toBase58());
         });
 
         it("should point the correct payment mint account address", () => {
-          expect(distributionAccountData.paymentMint).to.eql(PublicKey.default);
+          expect(
+            (distributionAccountData.paymentMint as PublicKey).toBase58()
+          ).to.eql(PublicKey.default.toBase58());
         });
       });
 
@@ -307,7 +319,10 @@ describe("wen_royalty_distribution", () => {
               commitment: "confirmed",
             });
 
-          listingAccountInfo = await connection.getAccountInfo(listing, "confirmed");
+          listingAccountInfo = await connection.getAccountInfo(
+            listing,
+            "confirmed"
+          );
           listingAccountData = wenWnsMarketplace.coder.accounts.decode(
             "listing",
             listingAccountInfo.data
@@ -325,11 +340,15 @@ describe("wen_royalty_distribution", () => {
         });
 
         it("should be owned by sale program", () => {
-          expect(listingAccountInfo.owner).to.eql(wenWnsMarketplaceId);
+          expect(listingAccountInfo.owner.toBase58()).to.eql(
+            wenWnsMarketplaceId.toBase58()
+          );
         });
 
         it("should point the listing account as delegate of NFT", () => {
-          expect(sellerTokenAccountData.delegate).to.eql(listing);
+          expect(sellerTokenAccountData.delegate.toBase58()).to.eql(
+            listing.toBase58()
+          );
         });
 
         it("should freeze the NFT", () => {
@@ -359,9 +378,18 @@ describe("wen_royalty_distribution", () => {
         let buyerTokenAccountData: Account;
 
         before(async () => {
-          distributionPreBalance = await connection.getBalance(distribution, "confirmed");
-          buyerPreBalance = await connection.getBalance(buyer.publicKey, "confirmed");
-          sellerPreBalance = await connection.getBalance(seller.publicKey, "confirmed");
+          distributionPreBalance = await connection.getBalance(
+            distribution,
+            "confirmed"
+          );
+          buyerPreBalance = await connection.getBalance(
+            buyer.publicKey,
+            "confirmed"
+          );
+          sellerPreBalance = await connection.getBalance(
+            seller.publicKey,
+            "confirmed"
+          );
 
           await wenWnsMarketplace.methods
             .buy({
@@ -402,7 +430,10 @@ describe("wen_royalty_distribution", () => {
           distributionPostBalance =
             (await connection.getBalance(distribution, "confirmed")) -
             distributionPreBalance;
-          buyerPostBalance = await connection.getBalance(buyer.publicKey, "confirmed");
+          buyerPostBalance = await connection.getBalance(
+            buyer.publicKey,
+            "confirmed"
+          );
           sellerPostBalance =
             (await connection.getBalance(seller.publicKey, "confirmed")) -
             sellerPreBalance;
@@ -429,7 +460,9 @@ describe("wen_royalty_distribution", () => {
 
         describe("the seller", () => {
           it("receive the payment minus royalties", () => {
-            expect(sellerPostBalance).to.eql(listingAmount.sub(royalty).toNumber());
+            expect(sellerPostBalance).to.eql(
+              listingAmount.sub(royalty).toNumber()
+            );
           });
           it("should not be the owner anymore", () => {
             expect(sellerTokenAccountData.amount.toString()).to.eql("0");
@@ -438,7 +471,9 @@ describe("wen_royalty_distribution", () => {
 
         describe("the buyer", () => {
           it("sent the payment", () => {
-            expect(buyerPostBalance).to.eql(buyerPreBalance - listingAmount.toNumber());
+            expect(buyerPostBalance).to.eql(
+              buyerPreBalance - listingAmount.toNumber()
+            );
           });
           it("should be the owner", () => {
             expect(buyerTokenAccountData.amount.toString()).to.eql("1");
@@ -606,7 +641,10 @@ describe("wen_royalty_distribution", () => {
         memberMintPublickey,
         wnsProgramId
       );
-      const approveAccount = getApproveAccountPda(memberMintPublickey, wnsProgramId);
+      const approveAccount = getApproveAccountPda(
+        memberMintPublickey,
+        wnsProgramId
+      );
 
       const listingAmount = new anchor.BN(500 * 10 ** 6);
       const royaltyBasisPoints = 1000;
@@ -627,9 +665,13 @@ describe("wen_royalty_distribution", () => {
           paymentMintAuthPublicKey
         );
 
-        await sendAndConfirmWNSTransaction(connection, createMintIxs, provider, true, [
-          paymentMintKeypair,
-        ]);
+        await sendAndConfirmWNSTransaction(
+          connection,
+          createMintIxs,
+          provider,
+          true,
+          [paymentMintKeypair]
+        );
 
         const { ixs: mintToIxs } = mintToBuyerSellerIx(
           paymentMintPublickey,
@@ -641,7 +683,13 @@ describe("wen_royalty_distribution", () => {
           sellerPaymentMintTokenAccount
         );
 
-        await sendAndConfirmWNSTransaction(connection, mintToIxs, provider, true, []);
+        await sendAndConfirmWNSTransaction(
+          connection,
+          mintToIxs,
+          provider,
+          true,
+          []
+        );
       });
 
       before(async () => {
@@ -744,7 +792,9 @@ describe("wen_royalty_distribution", () => {
             tokenProgram: TOKEN_2022_PROGRAM_ID,
             systemProgram: SystemProgram.programId,
           })
-          .preInstructions([ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 })])
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
+          ])
           .postInstructions(ixs)
           .signers([memberMintKeypair, seller])
           .rpc(preflightConfig);
@@ -756,15 +806,21 @@ describe("wen_royalty_distribution", () => {
         });
 
         it("should be owned by the distribution program", () => {
-          expect(distributionAccountInfo.owner).to.eql(wenDistributionProgramId);
+          expect(distributionAccountInfo.owner.toBase58()).to.eql(
+            wenDistributionProgramId.toBase58()
+          );
         });
 
         it("should point the correct group mint account address", () => {
-          expect(distributionAccountData.groupMint).to.eql(groupMintPublicKey);
+          expect(
+            (distributionAccountData.groupMint as PublicKey).toBase58()
+          ).to.eql(groupMintPublicKey.toBase58());
         });
 
         it("should point the correct payment mint account address", () => {
-          expect(distributionAccountData.paymentMint).to.eql(paymentMintPublickey);
+          expect(
+            (distributionAccountData.paymentMint as PublicKey).toBase58()
+          ).to.eql(paymentMintPublickey.toBase58());
         });
       });
 
@@ -797,7 +853,10 @@ describe("wen_royalty_distribution", () => {
               commitment: "confirmed",
             });
 
-          listingAccountInfo = await connection.getAccountInfo(listing, "confirmed");
+          listingAccountInfo = await connection.getAccountInfo(
+            listing,
+            "confirmed"
+          );
           listingAccountData = wenWnsMarketplace.coder.accounts.decode(
             "listing",
             listingAccountInfo.data
@@ -819,7 +878,9 @@ describe("wen_royalty_distribution", () => {
         });
 
         it("should point the listing account as delegate of NFT", () => {
-          expect(sellerTokenAccountData.delegate).to.eql(listing);
+          expect(sellerTokenAccountData.delegate.toBase58()).to.eql(
+            listing.toBase58()
+          );
         });
 
         it("should freeze the NFT", () => {
@@ -842,12 +903,13 @@ describe("wen_royalty_distribution", () => {
           TOKEN_2022_PROGRAM_ID
         );
 
-        const distributionPaymentMintTokenAccount = getAssociatedTokenAddressSync(
-          paymentMintPublickey,
-          distribution,
-          true,
-          TOKEN_2022_PROGRAM_ID
-        );
+        const distributionPaymentMintTokenAccount =
+          getAssociatedTokenAddressSync(
+            paymentMintPublickey,
+            distribution,
+            true,
+            TOKEN_2022_PROGRAM_ID
+          );
 
         let sellerPreBalance: number;
         let buyerPreBalance: number;
@@ -895,7 +957,8 @@ describe("wen_royalty_distribution", () => {
               seller: seller.publicKey,
               buyerPaymentTokenAccount: buyerPaymentMintTokenAccount,
               sellerPaymentTokenAccount: sellerPaymentMintTokenAccount,
-              distributionPaymentTokenAccount: distributionPaymentMintTokenAccount,
+              distributionPaymentTokenAccount:
+                distributionPaymentMintTokenAccount,
               mint: memberMintPublickey,
               paymentMint: paymentMintPublickey,
               buyerTokenAccount: buyerMemberMintTokenAccount,
@@ -977,7 +1040,9 @@ describe("wen_royalty_distribution", () => {
 
         describe("the seller", () => {
           it("receive the payment minus royalties", () => {
-            expect(sellerPostBalance).to.eql(listingAmount.sub(royalty).toNumber());
+            expect(sellerPostBalance).to.eql(
+              listingAmount.sub(royalty).toNumber()
+            );
           });
           it("should not be the owner anymore", () => {
             expect(sellerTokenAccountData.amount.toString()).to.eql("0");
@@ -987,7 +1052,9 @@ describe("wen_royalty_distribution", () => {
         describe("the buyer", () => {
           it("sent the payment", () => {
             console.log;
-            expect(buyerPostBalance).to.eql(buyerPreBalance - listingAmount.toNumber());
+            expect(buyerPostBalance).to.eql(
+              buyerPreBalance - listingAmount.toNumber()
+            );
           });
           it("should be the owner", () => {
             expect(buyerTokenAccountData.amount.toString()).to.eql("1");
@@ -996,12 +1063,13 @@ describe("wen_royalty_distribution", () => {
       });
 
       describe("after claiming", () => {
-        const distributionPaymentMintTokenAccount = getAssociatedTokenAddressSync(
-          paymentMintPublickey,
-          distribution,
-          true,
-          TOKEN_2022_PROGRAM_ID
-        );
+        const distributionPaymentMintTokenAccount =
+          getAssociatedTokenAddressSync(
+            paymentMintPublickey,
+            distribution,
+            true,
+            TOKEN_2022_PROGRAM_ID
+          );
 
         describe("creator 1", () => {
           const creator1PaymentMintTokenAccount = getAssociatedTokenAddressSync(
@@ -1025,7 +1093,8 @@ describe("wen_royalty_distribution", () => {
                 distribution,
                 paymentMint: paymentMintPublickey,
                 creatorPaymentTokenAccount: creator1PaymentMintTokenAccount,
-                distributionPaymentTokenAccount: distributionPaymentMintTokenAccount,
+                distributionPaymentTokenAccount:
+                  distributionPaymentMintTokenAccount,
                 wenDistributionProgram: wenDistributionProgramId,
                 associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
@@ -1086,7 +1155,8 @@ describe("wen_royalty_distribution", () => {
                 distribution,
                 paymentMint: paymentMintPublickey,
                 creatorPaymentTokenAccount: creator2PaymentMintTokenAccount,
-                distributionPaymentTokenAccount: distributionPaymentMintTokenAccount,
+                distributionPaymentTokenAccount:
+                  distributionPaymentMintTokenAccount,
                 wenDistributionProgram: wenDistributionProgramId,
                 associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,


### PR DESCRIPTION
### Issue
- Tests on main while referencing `0.30.0` resulted in seed constraint failures. 

```
  8) wen_royalty_distribution
       a sale
         using SPL token as payment
           "before all" hook in "using SPL token as payment":
     Error: AnchorError caused by account: group. Error Code: ConstraintSeeds. Error Number: 2006. Error Message: A seeds constraint was violated.
Program log: Left:
Program log: 7GQ4LtUnoFrD3a8v1VbdZXbgcJ27C8yGXzqn8tiYjrJm
Program log: Right:
Program log: 7GQ4LtUnqjhwXBSaocJUFmsTidXbxpHCZHotczepdku7
      at Function.parse (node_modules/.pnpm/@coral-xyz+anchor@0.30.0/node_modules/@coral-xyz/anchor/src/error.ts:167:14)
      at translateError (node_modules/.pnpm/@coral-xyz+anchor@0.30.0/node_modules/@coral-xyz/anchor/src/error.ts:276:35)
      at MethodsBuilder.rpc [as _rpcFn] (node_modules/.pnpm/@coral-xyz+anchor@0.30.0/node_modules/@coral-xyz/anchor/src/program/namespace/rpc.ts:35:29)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Changes
- Update to commit where patch to resolve stack overflow violations https://github.com/coral-xyz/anchor/pull/2913 added to anchor. This is not yet in a release but can be used with version 0.30.0 of the anchor CLI.
```
        after a sale
          royalties
            ✔ should be sent to the distribution vault
          the seller
            ✔ receive the payment minus royalties
            ✔ should not be the owner anymore
          the buyer
            ✔ sent the payment
            ✔ should be the owner
        after claiming
          creator 1
            ✔ should receive correct royalty funds
          creator 2
            ✔ should receive correct royalty funds


  63 passing (19s)

```
```
wen-program-library git:(base58-pubkey-tests) anchor --version
anchor-cli 0.30.0
```
- Convert string to base58 before comparing.