### PR TITLE
bugfix(program): Fix AccountNotInitialized Error for token accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "wen_new_standard"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/clients/js/wen_new_standard/package.json
+++ b/clients/js/wen_new_standard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wen-community/wen-new-standard",
-  "version": "0.4.0-alpha",
+  "version": "0.4.1-alpha",
   "description": "An open and composable NFT standard on Solana.",
   "main": "dist/src/index.js",
   "types": "dist/src/types/index.d.ts",

--- a/clients/js/wen_new_standard/src/generated/instructions/addMintToGroup.ts
+++ b/clients/js/wen_new_standard/src/generated/instructions/addMintToGroup.ts
@@ -68,7 +68,7 @@ export type AddMintToGroupInstruction<
         ? WritableAccount<TAccountMember>
         : TAccountMember,
       TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
+        ? WritableAccount<TAccountMint>
         : TAccountMint,
       TAccountManager extends string
         ? ReadonlyAccount<TAccountManager>
@@ -175,7 +175,7 @@ export function getAddMintToGroupInstruction<
     authority: { value: input.authority ?? null, isWritable: false },
     group: { value: input.group ?? null, isWritable: true },
     member: { value: input.member ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
+    mint: { value: input.mint ?? null, isWritable: true },
     manager: { value: input.manager ?? null, isWritable: false },
     systemProgram: { value: input.systemProgram ?? null, isWritable: false },
     tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },

--- a/clients/js/wen_new_standard/src/generated/instructions/approveTransfer.ts
+++ b/clients/js/wen_new_standard/src/generated/instructions/approveTransfer.ts
@@ -56,6 +56,7 @@ export type ApproveTransferInstruction<
   TAccountTokenProgram extends
     | string
     | IAccountMeta<string> = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb',
+  TAccountPaymentTokenProgram extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -96,6 +97,9 @@ export type ApproveTransferInstruction<
       TAccountTokenProgram extends string
         ? ReadonlyAccount<TAccountTokenProgram>
         : TAccountTokenProgram,
+      TAccountPaymentTokenProgram extends string
+        ? ReadonlyAccount<TAccountPaymentTokenProgram>
+        : TAccountPaymentTokenProgram,
       ...TRemainingAccounts,
     ]
   >;
@@ -149,6 +153,7 @@ export type ApproveTransferInput<
   TAccountSystemProgram extends string = string,
   TAccountDistributionProgram extends string = string,
   TAccountTokenProgram extends string = string,
+  TAccountPaymentTokenProgram extends string = string,
 > = {
   payer: TransactionSigner<TAccountPayer>;
   authority: TransactionSigner<TAccountAuthority>;
@@ -161,6 +166,7 @@ export type ApproveTransferInput<
   systemProgram?: Address<TAccountSystemProgram>;
   distributionProgram?: Address<TAccountDistributionProgram>;
   tokenProgram?: Address<TAccountTokenProgram>;
+  paymentTokenProgram?: Address<TAccountPaymentTokenProgram>;
   buyAmount: ApproveTransferInstructionDataArgs['buyAmount'];
 };
 
@@ -176,6 +182,7 @@ export function getApproveTransferInstruction<
   TAccountSystemProgram extends string,
   TAccountDistributionProgram extends string,
   TAccountTokenProgram extends string,
+  TAccountPaymentTokenProgram extends string,
 >(
   input: ApproveTransferInput<
     TAccountPayer,
@@ -188,7 +195,8 @@ export function getApproveTransferInstruction<
     TAccountDistributionAccount,
     TAccountSystemProgram,
     TAccountDistributionProgram,
-    TAccountTokenProgram
+    TAccountTokenProgram,
+    TAccountPaymentTokenProgram
   >
 ): ApproveTransferInstruction<
   typeof WEN_NEW_STANDARD_PROGRAM_ADDRESS,
@@ -202,7 +210,8 @@ export function getApproveTransferInstruction<
   TAccountDistributionAccount,
   TAccountSystemProgram,
   TAccountDistributionProgram,
-  TAccountTokenProgram
+  TAccountTokenProgram,
+  TAccountPaymentTokenProgram
 > {
   // Program address.
   const programAddress = WEN_NEW_STANDARD_PROGRAM_ADDRESS;
@@ -232,6 +241,10 @@ export function getApproveTransferInstruction<
       isWritable: false,
     },
     tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
+    paymentTokenProgram: {
+      value: input.paymentTokenProgram ?? null,
+      isWritable: false,
+    },
   };
   const accounts = originalAccounts as Record<
     keyof typeof originalAccounts,
@@ -269,6 +282,7 @@ export function getApproveTransferInstruction<
       getAccountMeta(accounts.systemProgram),
       getAccountMeta(accounts.distributionProgram),
       getAccountMeta(accounts.tokenProgram),
+      getAccountMeta(accounts.paymentTokenProgram),
     ],
     programAddress,
     data: getApproveTransferInstructionDataEncoder().encode(
@@ -286,7 +300,8 @@ export function getApproveTransferInstruction<
     TAccountDistributionAccount,
     TAccountSystemProgram,
     TAccountDistributionProgram,
-    TAccountTokenProgram
+    TAccountTokenProgram,
+    TAccountPaymentTokenProgram
   >;
 
   return instruction;
@@ -309,6 +324,7 @@ export type ParsedApproveTransferInstruction<
     systemProgram: TAccountMetas[8];
     distributionProgram: TAccountMetas[9];
     tokenProgram: TAccountMetas[10];
+    paymentTokenProgram?: TAccountMetas[11] | undefined;
   };
   data: ApproveTransferInstructionData;
 };
@@ -321,7 +337,7 @@ export function parseApproveTransferInstruction<
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
 ): ParsedApproveTransferInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 11) {
+  if (instruction.accounts.length < 12) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
   }
@@ -351,6 +367,7 @@ export function parseApproveTransferInstruction<
       systemProgram: getNextAccount(),
       distributionProgram: getNextAccount(),
       tokenProgram: getNextAccount(),
+      paymentTokenProgram: getNextOptionalAccount(),
     },
     data: getApproveTransferInstructionDataDecoder().decode(instruction.data),
   };

--- a/clients/js/wen_new_standard/src/generated/instructions/updateGroupAccount.ts
+++ b/clients/js/wen_new_standard/src/generated/instructions/updateGroupAccount.ts
@@ -67,7 +67,7 @@ export type UpdateGroupAccountInstruction<
         ? WritableAccount<TAccountGroup>
         : TAccountGroup,
       TAccountMint extends string
-        ? ReadonlyAccount<TAccountMint>
+        ? WritableAccount<TAccountMint>
         : TAccountMint,
       TAccountSystemProgram extends string
         ? ReadonlyAccount<TAccountSystemProgram>
@@ -168,7 +168,7 @@ export function getUpdateGroupAccountInstruction<
     payer: { value: input.payer ?? null, isWritable: true },
     authority: { value: input.authority ?? null, isWritable: false },
     group: { value: input.group ?? null, isWritable: true },
-    mint: { value: input.mint ?? null, isWritable: false },
+    mint: { value: input.mint ?? null, isWritable: true },
     systemProgram: { value: input.systemProgram ?? null, isWritable: false },
     tokenProgram: { value: input.tokenProgram ?? null, isWritable: false },
   };

--- a/clients/rust/wen_new_standard/Cargo.lock
+++ b/clients/rust/wen_new_standard/Cargo.lock
@@ -5687,7 +5687,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "wen_new_standard"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",

--- a/clients/rust/wen_new_standard/Cargo.toml
+++ b/clients/rust/wen_new_standard/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "An open and composable NFT standard on Solana."
 name = "wen_new_standard"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 
 [workspace]

--- a/clients/rust/wen_new_standard/src/generated/instructions/add_mint_to_group.rs
+++ b/clients/rust/wen_new_standard/src/generated/instructions/add_mint_to_group.rs
@@ -51,7 +51,7 @@ impl AddMintToGroup {
             self.member,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.mint, false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -104,7 +104,7 @@ impl Default for AddMintToGroupInstructionData {
 ///   1. `[signer]` authority
 ///   2. `[writable]` group
 ///   3. `[writable]` member
-///   4. `[]` mint
+///   4. `[writable]` mint
 ///   5. `[]` manager
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` token_program (default to `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`)
@@ -314,7 +314,7 @@ impl<'a, 'b> AddMintToGroupCpi<'a, 'b> {
             *self.member.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.mint.key,
             false,
         ));
@@ -374,7 +374,7 @@ impl<'a, 'b> AddMintToGroupCpi<'a, 'b> {
 ///   1. `[signer]` authority
 ///   2. `[writable]` group
 ///   3. `[writable]` member
-///   4. `[]` mint
+///   4. `[writable]` mint
 ///   5. `[]` manager
 ///   6. `[]` system_program
 ///   7. `[]` token_program

--- a/clients/rust/wen_new_standard/src/generated/instructions/update_group_account.rs
+++ b/clients/rust/wen_new_standard/src/generated/instructions/update_group_account.rs
@@ -48,7 +48,7 @@ impl UpdateGroupAccount {
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.group, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.mint, false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -106,7 +106,7 @@ pub struct UpdateGroupAccountInstructionArgs {
 ///   0. `[writable, signer]` payer
 ///   1. `[]` authority
 ///   2. `[writable]` group
-///   3. `[]` mint
+///   3. `[writable]` mint
 ///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   5. `[optional]` token_program (default to `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`)
 #[derive(Clone, Debug, Default)]
@@ -300,7 +300,7 @@ impl<'a, 'b> UpdateGroupAccountCpi<'a, 'b> {
             *self.group.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.mint.key,
             false,
         ));
@@ -357,7 +357,7 @@ impl<'a, 'b> UpdateGroupAccountCpi<'a, 'b> {
 ///   0. `[writable, signer]` payer
 ///   1. `[]` authority
 ///   2. `[writable]` group
-///   3. `[]` mint
+///   3. `[writable]` mint
 ///   4. `[]` system_program
 ///   5. `[]` token_program
 #[derive(Clone, Debug)]

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wen_new_standard"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 description = "An open and composable NFT standard on Solana."
 edition = "2021"
 

--- a/programs/wen_new_standard/src/instructions/group/update.rs
+++ b/programs/wen_new_standard/src/instructions/group/update.rs
@@ -29,6 +29,7 @@ pub struct UpdateGroupAccount<'info> {
     )]
     pub group: Account<'info, TokenGroup>,
     #[account(
+        mut,
         mint::token_program = token_program,
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,

--- a/programs/wen_new_standard/src/instructions/mint/group/add.rs
+++ b/programs/wen_new_standard/src/instructions/mint/group/add.rs
@@ -32,6 +32,7 @@ pub struct AddGroup<'info> {
     )]
     pub member: Account<'info, TokenGroupMember>,
     #[account(
+        mut,
         mint::token_program = TOKEN22
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,

--- a/programs/wen_new_standard/src/utils.rs
+++ b/programs/wen_new_standard/src/utils.rs
@@ -32,7 +32,9 @@ pub fn update_account_lamports_to_minimum_balance<'info>(
     payer: AccountInfo<'info>,
     system_program: AccountInfo<'info>,
 ) -> Result<()> {
-    let extra_lamports = Rent::get()?.minimum_balance(account.data_len()) - account.get_lamports();
+    let extra_lamports = Rent::get()?
+        .minimum_balance(account.data_len())
+        .saturating_sub(account.get_lamports());
     if extra_lamports > 0 {
         invoke(
             &transfer(payer.key, account.key, extra_lamports),

--- a/programs/wen_royalty_distribution/src/errors.rs
+++ b/programs/wen_royalty_distribution/src/errors.rs
@@ -8,6 +8,8 @@ pub enum DistributionErrors {
     InvalidCreatorPctAmount,
     #[msg("Invalid payment token account")]
     InvalidPaymentTokenAccount,
+    #[msg("Invalid payment token program")]
+    InvalidPaymentTokenProgram,
     #[msg("Arithmetic overflow")]
     ArithmeticOverflow,
 }

--- a/programs/wen_wns_marketplace/src/instructions/listing/buy.rs
+++ b/programs/wen_wns_marketplace/src/instructions/listing/buy.rs
@@ -4,9 +4,11 @@ use anchor_lang::{
 };
 use anchor_spl::{
     associated_token::AssociatedToken,
-    token_2022::spl_token_2022::{extension::StateWithExtensions, state::Mint as StateMint},
-    token_2022::{transfer_checked, Token2022, TransferChecked},
-    token_interface::{Mint, TokenAccount},
+    token_2022::{
+        spl_token_2022::{extension::StateWithExtensions, state::Mint as StateMint},
+        transfer_checked, Token2022, TransferChecked,
+    },
+    token_interface::{Mint, TokenAccount, TokenInterface},
 };
 use wen_new_standard::{
     cpi::{
@@ -90,6 +92,7 @@ pub struct FulfillListing<'info> {
     pub distribution_program: Program<'info, WenRoyaltyDistribution>,
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub token_program: Program<'info, Token2022>,
+    pub payment_token_program: Option<Interface<'info, TokenInterface>>,
     pub system_program: Program<'info, System>,
 
     /* Optional accounts */
@@ -97,21 +100,21 @@ pub struct FulfillListing<'info> {
         mut,
         token::authority = seller,
         token::mint = payment_mint,
-        token::token_program = token_program
+        token::token_program = payment_token_program
     )]
     pub seller_payment_token_account: Option<Box<InterfaceAccount<'info, TokenAccount>>>,
     #[account(
         mut,
         token::authority = buyer,
         token::mint = payment_mint,
-        token::token_program = token_program
+        token::token_program = payment_token_program
     )]
     pub buyer_payment_token_account: Option<Box<InterfaceAccount<'info, TokenAccount>>>,
     #[account(
         mut,
         token::authority = distribution,
         token::mint = payment_mint,
-        token::token_program = token_program
+        token::token_program = payment_token_program
     )]
     pub distribution_payment_token_account: Option<Box<InterfaceAccount<'info, TokenAccount>>>,
 }
@@ -169,7 +172,11 @@ pub fn handler(ctx: Context<FulfillListing>, args: FulfillListingArgs) -> Result
 
         transfer_checked(
             CpiContext::new(
-                ctx.accounts.token_program.to_account_info(),
+                ctx.accounts
+                    .payment_token_program
+                    .clone()
+                    .unwrap()
+                    .to_account_info(),
                 TransferChecked {
                     authority: ctx.accounts.buyer.to_account_info(),
                     from: buyer_payment_token_account.to_account_info(),
@@ -203,6 +210,12 @@ pub fn handler(ctx: Context<FulfillListing>, args: FulfillListingArgs) -> Result
         .as_ref()
         .map(|d| d.to_account_info());
 
+    let payment_token_program = ctx
+        .accounts
+        .payment_token_program
+        .as_ref()
+        .map(|d| d.to_account_info());
+
     approve_transfer(
         CpiContext::new(
             ctx.accounts.wns_program.to_account_info(),
@@ -217,6 +230,7 @@ pub fn handler(ctx: Context<FulfillListing>, args: FulfillListingArgs) -> Result
                 approve_account: ctx.accounts.approve_account.to_account_info(),
                 distribution_program: ctx.accounts.distribution_program.to_account_info(),
                 token_program: ctx.accounts.token_program.to_account_info(),
+                payment_token_program: payment_token_program,
                 system_program: ctx.accounts.system_program.to_account_info(),
             },
         ),

--- a/tests/wen_royalty_distribution.test.ts
+++ b/tests/wen_royalty_distribution.test.ts
@@ -2,7 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 import { faker } from "@faker-js/faker";
 import { WenNewStandard } from "../target/types/wen_new_standard";
 import { WenWnsMarketplace } from "./../target/types/wen_wns_marketplace";
-import { WenRoyaltyDistribution } from "./../clients/wns-sdk/src/programs/types/wen_royalty_distribution";
+import { WenRoyaltyDistribution } from "./../target/types/wen_royalty_distribution";
 import {
   Keypair,
   LAMPORTS_PER_SOL,
@@ -15,7 +15,7 @@ import {
 
 import {
   airdrop,
-  createMint2022Ix,
+  createMintTokenKegIx,
   getApproveAccountPda,
   getDistributionAccountPda,
   getExtraMetasAccountPda,
@@ -30,6 +30,7 @@ import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   Account,
   TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountInstruction,
   getAccount,
   getAssociatedTokenAddressSync,
@@ -395,7 +396,7 @@ describe("wen_royalty_distribution", () => {
             .buy({
               buyAmount: listingAmount,
             })
-            .accountsPartial({
+            .accountsStrict({
               approveAccount,
               extraMetasAccount,
               distribution,
@@ -415,6 +416,7 @@ describe("wen_royalty_distribution", () => {
               distributionProgram: wenDistributionProgramId,
               associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
               tokenProgram: TOKEN_2022_PROGRAM_ID,
+              paymentTokenProgram: null,
               systemProgram: SystemProgram.programId,
             })
             .preInstructions([
@@ -607,7 +609,7 @@ describe("wen_royalty_distribution", () => {
         paymentMintPublickey,
         seller.publicKey,
         false,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_PROGRAM_ID
       );
 
       const buyerMemberMintTokenAccount = getAssociatedTokenAddressSync(
@@ -621,7 +623,7 @@ describe("wen_royalty_distribution", () => {
         paymentMintPublickey,
         buyer.publicKey,
         false,
-        TOKEN_2022_PROGRAM_ID
+        TOKEN_PROGRAM_ID
       );
 
       const group = getGroupAccountPda(groupMintPublicKey, wnsProgramId);
@@ -658,7 +660,7 @@ describe("wen_royalty_distribution", () => {
       let distributionAccountData;
 
       before(async () => {
-        const { ixs: createMintIxs } = await createMint2022Ix(
+        const { ixs: createMintIxs } = await createMintTokenKegIx(
           connection,
           paymentMintPublickey,
           paymentMintAuthPublicKey,
@@ -893,14 +895,14 @@ describe("wen_royalty_distribution", () => {
           paymentMintPublickey,
           buyer.publicKey,
           false,
-          TOKEN_2022_PROGRAM_ID
+          TOKEN_PROGRAM_ID
         );
 
         const sellerPaymentMintTokenAccount = getAssociatedTokenAddressSync(
           paymentMintPublickey,
           seller.publicKey,
           false,
-          TOKEN_2022_PROGRAM_ID
+          TOKEN_PROGRAM_ID
         );
 
         const distributionPaymentMintTokenAccount =
@@ -908,7 +910,7 @@ describe("wen_royalty_distribution", () => {
             paymentMintPublickey,
             distribution,
             true,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_PROGRAM_ID
           );
 
         let sellerPreBalance: number;
@@ -927,7 +929,7 @@ describe("wen_royalty_distribution", () => {
                 connection,
                 buyerPaymentMintTokenAccount,
                 "confirmed",
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_PROGRAM_ID
               )
             ).amount.toString()
           );
@@ -937,7 +939,7 @@ describe("wen_royalty_distribution", () => {
                 connection,
                 sellerPaymentMintTokenAccount,
                 "confirmed",
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_PROGRAM_ID
               )
             ).amount.toString()
           );
@@ -967,6 +969,7 @@ describe("wen_royalty_distribution", () => {
               distributionProgram: wenDistributionProgramId,
               associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
               tokenProgram: TOKEN_2022_PROGRAM_ID,
+              paymentTokenProgram: TOKEN_PROGRAM_ID,
               systemProgram: SystemProgram.programId,
             })
             .preInstructions([
@@ -976,7 +979,7 @@ describe("wen_royalty_distribution", () => {
                 distributionPaymentMintTokenAccount,
                 distribution,
                 paymentMintPublickey,
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_PROGRAM_ID
               ),
             ])
             .signers([buyer])
@@ -992,7 +995,7 @@ describe("wen_royalty_distribution", () => {
                 connection,
                 distributionPaymentMintTokenAccount,
                 "confirmed",
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_PROGRAM_ID
               )
             ).amount.toString()
           );
@@ -1002,7 +1005,7 @@ describe("wen_royalty_distribution", () => {
                 connection,
                 buyerPaymentMintTokenAccount,
                 "confirmed",
-                TOKEN_2022_PROGRAM_ID
+                TOKEN_PROGRAM_ID
               )
             ).amount.toString()
           );
@@ -1013,7 +1016,7 @@ describe("wen_royalty_distribution", () => {
                   connection,
                   sellerPaymentMintTokenAccount,
                   "confirmed",
-                  TOKEN_2022_PROGRAM_ID
+                  TOKEN_PROGRAM_ID
                 )
               ).amount.toString()
             ) - sellerPreBalance;
@@ -1068,7 +1071,7 @@ describe("wen_royalty_distribution", () => {
             paymentMintPublickey,
             distribution,
             true,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_PROGRAM_ID
           );
 
         describe("creator 1", () => {
@@ -1076,7 +1079,7 @@ describe("wen_royalty_distribution", () => {
             paymentMintPublickey,
             creator1.publicKey,
             true,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_PROGRAM_ID
           );
 
           let creator1PostBalance: number;
@@ -1097,7 +1100,7 @@ describe("wen_royalty_distribution", () => {
                   distributionPaymentMintTokenAccount,
                 wenDistributionProgram: wenDistributionProgramId,
                 associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
+                tokenProgram: TOKEN_PROGRAM_ID,
                 systemProgram: SystemProgram.programId,
               })
               .preInstructions([
@@ -1106,7 +1109,7 @@ describe("wen_royalty_distribution", () => {
                   creator1PaymentMintTokenAccount,
                   creator1.publicKey,
                   paymentMintPublickey,
-                  TOKEN_2022_PROGRAM_ID
+                  TOKEN_PROGRAM_ID
                 ),
               ])
               .signers([creator1])
@@ -1122,7 +1125,7 @@ describe("wen_royalty_distribution", () => {
                   connection,
                   creator1PaymentMintTokenAccount,
                   "confirmed",
-                  TOKEN_2022_PROGRAM_ID
+                  TOKEN_PROGRAM_ID
                 )
               ).amount.toString()
             );
@@ -1138,7 +1141,7 @@ describe("wen_royalty_distribution", () => {
             paymentMintPublickey,
             creator2.publicKey,
             true,
-            TOKEN_2022_PROGRAM_ID
+            TOKEN_PROGRAM_ID
           );
 
           let creator2PostBalance: number;
@@ -1159,7 +1162,7 @@ describe("wen_royalty_distribution", () => {
                   distributionPaymentMintTokenAccount,
                 wenDistributionProgram: wenDistributionProgramId,
                 associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-                tokenProgram: TOKEN_2022_PROGRAM_ID,
+                tokenProgram: TOKEN_PROGRAM_ID,
                 systemProgram: SystemProgram.programId,
               })
               .preInstructions([
@@ -1168,7 +1171,7 @@ describe("wen_royalty_distribution", () => {
                   creator2PaymentMintTokenAccount,
                   creator2.publicKey,
                   paymentMintPublickey,
-                  TOKEN_2022_PROGRAM_ID
+                  TOKEN_PROGRAM_ID
                 ),
               ])
               .signers([creator2])
@@ -1184,7 +1187,7 @@ describe("wen_royalty_distribution", () => {
                   connection,
                   creator2PaymentMintTokenAccount,
                   "confirmed",
-                  TOKEN_2022_PROGRAM_ID
+                  TOKEN_PROGRAM_ID
                 )
               ).amount.toString()
             );


### PR DESCRIPTION
This PR focusses the fix for the following errors
1. Error code 3012 `AccountNotInitialized` for all payment based token accounts for royalties. 
2. A memory drop bug that caused when calling `modify_royalties` instruction
3. Cleanup filter on addresses for additional_metadata when calling `modify_royalties` instruction
4. Updated tests and sale program to specifically showcase a seperate token program. 